### PR TITLE
Add tests for subtraction and division operations in DartDecimal

### DIFF
--- a/test/dart_decimal_test.dart
+++ b/test/dart_decimal_test.dart
@@ -141,5 +141,29 @@ void main() {
       expect(result.amount, 2);
       expect(result.precision, 1);
     });
+
+    test('890.9913293236 - 1.446468288', () {
+      final left = DartDecimal(amount: 8909913293236, precision: 10);
+      final right = DartDecimal.fromDecimal(amount: 1446468288, precision: 9);
+      final result = left - right;
+      final roundToTen = result.roundToPrecision(10);
+      expect(roundToTen.amount, 8895448610356);
+      expect(roundToTen.precision, 10);
+    });
+  });
+
+  group("Divide and Multiply", () {
+    test('890.9913293236 / 37160', () {
+      final left = DartDecimal(amount: 8909913293236, precision: 10);
+      final right = DartDecimal(amount: 37160, precision: 0);
+      final result = left / right;
+      expect(result.amount, 23977161714843917);
+      expect(result.precision, 18);
+
+      final multiplied = result * DartDecimal(amount: 60, precision: 0);
+
+      expect(multiplied.amount, 1438629702890635);
+      expect(multiplied.precision, 15);
+    });
   });
 }


### PR DESCRIPTION
This pull request adds new unit tests to improve the test coverage for arithmetic operations in the `DartDecimal` class. The tests cover subtraction, division, and multiplication, ensuring the correctness of these operations with various levels of precision.

### Added Unit Tests for Arithmetic Operations:

* **Subtraction Test**: Added a test for subtracting two `DartDecimal` instances with different precisions, verifying the result is correctly rounded to a specified precision. (`test/dart_decimal_test.dart`, [test/dart_decimal_test.dartR144-R167](diffhunk://#diff-0ef7d220410914c5475051a6680baf48553779926b8a1c37c830ed4c3ffb58a0R144-R167))
* **Division and Multiplication Test**: Added a test for dividing a `DartDecimal` instance by another number and subsequently multiplying the result, ensuring the precision is maintained correctly throughout the operations. (`test/dart_decimal_test.dart`, [test/dart_decimal_test.dartR144-R167](diffhunk://#diff-0ef7d220410914c5475051a6680baf48553779926b8a1c37c830ed4c3ffb58a0R144-R167))